### PR TITLE
fix(script): Updated script names

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "lint": "eslint --fix --max-warnings=0 .",
     "format": "prettier --write --check --config ./.prettierrc './src/**/*.{js,jsx,ts,tsx,css,md,json}'",
     "fastformat": "pretty-quick --staged './**/*.{js,jsx,ts,tsx,css,md,json}'",
-    "create": "docker run --name trak -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres",
+    "createdb": "docker run --name trak -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres",
     "precommit": "yarn fastformat && yarn lint",
     "heroku-postbuild": "yarn build",
     "loaddata": "npx fixtures ./src/fixtures",
-    "remove" : "docker rm -f -v trak",
+    "deletedb" : "docker rm -f -v trak",
     "push" : "npx prisma db push --preview-feature",
-    "fresh": "yarn remove && yarn create && sleep 1 && yarn push && yarn loaddata"
+    "fresh": "yarn deletedb && yarn createdb && sleep 1 && yarn push && yarn loaddata"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Yarn remove og Yarn create er allerede definerte oppgaver for Yarn så vi kan ikke overskride disse navnene:

https://classic.yarnpkg.com/en/docs/cli/remove/

https://classic.yarnpkg.com/en/docs/cli/create/

Har derfor oppdatert disse navnene igjen slik at vi får kjørt Yarn fresh