### PR TITLE
fix(Info): Removed infobutton

### DIFF
--- a/src/components/views/ansatt/TaskRow.tsx
+++ b/src/components/views/ansatt/TaskRow.tsx
@@ -1,5 +1,5 @@
-import { Box, IconButton } from '@material-ui/core';
-import { CheckBox as CheckBoxIcon, CheckBoxOutlineBlank as CheckBoxOutlineBlankIcon, Info as InfoIcon } from '@material-ui/icons';
+import { Box, ButtonBase, IconButton } from '@material-ui/core';
+import { CheckBox as CheckBoxIcon, CheckBoxOutlineBlank as CheckBoxOutlineBlankIcon } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/styles';
 import Avatar from 'components/Avatar';
 import InfoModal from 'components/InfoModal';
@@ -20,6 +20,12 @@ const useStyles = makeStyles({
   completedTask: {
     textDecoration: 'line-through',
   },
+  textButton: {
+    '&:hover': {
+      background: theme.palette.text.secondary,
+      borderRadius: theme.spacing(0.5),
+    },
+  },
 });
 
 type TaskRowProps = {
@@ -39,12 +45,12 @@ const TaskRow = ({ employeeTask }: TaskRowProps) => {
         <IconButton onClick={() => toggleCheckBox(employeeTask, completed, setCompleted, showSnackbar)} size='small'>
           {completed ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
         </IconButton>
-        <Typo className={completed && classes.completedTask} color={!completed && 'disabled'} noWrap variant='body1'>
-          {employeeTask.task.title}
-        </Typo>
-        <IconButton onClick={() => setModalIsOpen(true)} size='small'>
-          <InfoIcon color={completed ? 'inherit' : 'primary'} />
-        </IconButton>
+        <ButtonBase className={classes.textButton} onClick={() => setModalIsOpen(true)}>
+          <Typo className={completed && classes.completedTask} color={!completed && 'disabled'} noWrap variant='body1'>
+            {employeeTask.task.title}
+          </Typo>
+        </ButtonBase>
+
         {modalIsOpen && <InfoModal closeModal={() => setModalIsOpen(false)} employee_task_id={employeeTask.id} modalIsOpen={modalIsOpen} />}
       </Box>
       {employeeTask.responsible.id !== employee.hrManager.id && (

--- a/src/components/views/mine-oppgaver/TaskRow.tsx
+++ b/src/components/views/mine-oppgaver/TaskRow.tsx
@@ -1,5 +1,5 @@
-import { IconButton, makeStyles } from '@material-ui/core';
-import { CheckBox, CheckBoxOutlineBlank, Info } from '@material-ui/icons';
+import { ButtonBase, IconButton, makeStyles } from '@material-ui/core';
+import { CheckBox, CheckBoxOutlineBlank } from '@material-ui/icons';
 import Avatar from 'components/Avatar';
 import InfoModal from 'components/InfoModal';
 import Typo from 'components/Typo';
@@ -37,6 +37,12 @@ const useStyles = makeStyles({
       background: theme.palette.text.secondary,
     },
   },
+  textButton: {
+    '&:hover': {
+      background: theme.palette.text.secondary,
+      borderRadius: theme.spacing(0.5),
+    },
+  },
 });
 
 const TaskRow = ({ data }: { data: IEmployeeTask }) => {
@@ -52,12 +58,11 @@ const TaskRow = ({ data }: { data: IEmployeeTask }) => {
         <IconButton onClick={() => toggleCheckBox(data, completed, setCompleted, showSnackbar)} size='small'>
           {completed ? <CheckBox /> : <CheckBoxOutlineBlank />}
         </IconButton>
-        <Typo className={completed ? classes.completedTask : undefined} noWrap>
-          {data.task.title}
-        </Typo>
-        <IconButton onClick={() => setModalIsOpen(true)} size='small'>
-          <Info color={completed ? 'inherit' : 'primary'} />
-        </IconButton>
+        <ButtonBase className={classes.textButton} onClick={() => setModalIsOpen(true)}>
+          <Typo className={completed ? classes.completedTask : undefined} noWrap>
+            {data.task.title}
+          </Typo>
+        </ButtonBase>
         {modalIsOpen && <InfoModal closeModal={() => setModalIsOpen(false)} employee_task_id={data.id} modalIsOpen={modalIsOpen} />}
       </div>
       <div


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49594236/112157589-a6f96300-8be7-11eb-8bf6-4d4b17251821.png)

Man må nå trykke på selve oppgavetittelen for å få opp modalen. Dette fordi at I-ikonet er feil å bruke i denne sammenhengen. 