### PR TITLE
feat(Removed id): Removed id

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -73,7 +73,6 @@ const ResponsibleSelector = ({ employeeTask }: { employeeTask: IEmployeeTask }) 
             ...(formData.responsible.employeeSettings?.slack && {
               slackData: {
                 email: formData.responsible.email,
-                text: `Du har blitt delegert arbeidsoppgaven ${employeeTask.task.title} av ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`,
               },
             }),
           });

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -65,14 +65,14 @@ const ResponsibleSelector = ({ employeeTask }: { employeeTask: IEmployeeTask }) 
           dueDate: employeeTask.dueDate,
           responsibleId: formData.responsible?.id,
         });
-        const employeeWantsDelegateNotifications = formData.responsible.employeeSettings.notificationSettings.includes('DELEGATE');
+        const employeeWantsDelegateNotifications = formData.responsible.employeeSettings?.notificationSettings?.includes('DELEGATE');
         if (employeeWantsDelegateNotifications) {
           await axios.post('/api/notification', {
             description: `Du har blitt delegert arbeidsoppgaven "${employeeTask.task.title}" av ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`,
             employeeId: formData.responsible?.id,
             ...(formData.responsible.employeeSettings?.slack && {
               slackData: {
-                channel: formData.responsible.employeeSettings.slack,
+                email: formData.responsible.email,
                 text: `Du har blitt delegert arbeidsoppgaven ${employeeTask.task.title} av ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`,
               },
             }),
@@ -85,7 +85,7 @@ const ResponsibleSelector = ({ employeeTask }: { employeeTask: IEmployeeTask }) 
           showSnackbar('Ansvarlig byttet', 'success');
         });
       } catch (error) {
-        showSnackbar(error.response.data?.message || 'Noe gikk galt', 'error');
+        showSnackbar(error.response?.data?.message || 'Noe gikk galt', 'error');
       }
     }
   });

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -28,6 +28,15 @@ export default NextAuth({
           },
         });
         if (user && profile.verified_email) {
+          await prisma.employeeSettings.upsert({
+            where: {
+              employeeId: user.id,
+            },
+            update: {},
+            create: {
+              employeeId: user.id,
+            },
+          });
           return true;
         }
         // eslint-disable-next-line no-empty

--- a/src/pages/api/employees.ts
+++ b/src/pages/api/employees.ts
@@ -11,10 +11,12 @@ export default withAuth(async function (req: NextApiRequest, res: NextApiRespons
         id: true,
         firstName: true,
         lastName: true,
+        email: true,
         imageUrl: true,
         employeeSettings: {
           select: {
             slack: true,
+            notificationSettings: true,
           },
         },
       },

--- a/src/pages/api/notification.ts
+++ b/src/pages/api/notification.ts
@@ -18,7 +18,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
         },
       });
       if (slackData) {
-        slackMessager(slackData.email, slackData.text);
+        slackMessager(slackData.email, description);
       }
       res.status(HttpStatusCode.CREATED).json(newNotification);
     } catch (err) {

--- a/src/pages/api/notification.ts
+++ b/src/pages/api/notification.ts
@@ -18,7 +18,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
         },
       });
       if (slackData) {
-        slackMessager(slackData.channel, slackData.text);
+        slackMessager(slackData.email, slackData.text);
       }
       res.status(HttpStatusCode.CREATED).json(newNotification);
     } catch (err) {

--- a/src/pages/innstillinger.tsx
+++ b/src/pages/innstillinger.tsx
@@ -1,6 +1,5 @@
 import { Button, Checkbox as MuiCheckbox, FormControlLabel, FormGroup, makeStyles } from '@material-ui/core';
 import axios from 'axios';
-import TextField from 'components/form/TextField';
 import Typo from 'components/Typo';
 import useSnackbar from 'context/Snackbar';
 import { useUser } from 'context/User';
@@ -32,19 +31,18 @@ const useStyles = makeStyles({
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
   try {
-    const mySettings = await prisma.employeeSettings.findUnique({
+    const mySettings = await prisma.employeeSettings.upsert({
       where: {
+        employeeId: session?.user?.id,
+      },
+      update: {},
+      create: {
         employeeId: session?.user?.id,
       },
     });
     return { props: { mySettings } };
   } catch (err) {
-    const mySettings = await prisma.employeeSettings.create({
-      data: {
-        employeeId: session?.user?.id,
-      },
-    });
-    return { props: { mySettings } };
+    return { props: {} };
   }
 };
 
@@ -55,7 +53,7 @@ const Settings = ({ mySettings }: InferGetServerSidePropsType<typeof getServerSi
 
   const defaultNotificationSettingsValue = mySettings.notificationSettings.reduce((object, key) => ((object[key] = true), object), {});
 
-  const { register, errors, control, handleSubmit } = useForm({
+  const { control, handleSubmit } = useForm({
     reValidateMode: 'onChange',
     defaultValues: useMemo(
       () => ({
@@ -104,7 +102,7 @@ const Settings = ({ mySettings }: InferGetServerSidePropsType<typeof getServerSi
         </div>
         <form noValidate onSubmit={onSubmit}>
           <div>
-            <TextField errors={errors} fullWidth={false} label='Slack member id' name='slack' register={register} />
+            <Checkbox control={control} key={'slack'} label='Jeg ønsker varslinger på Slack' name={'slack'} />
             <div style={{ padding: `${theme.spacing(4)} 0` }}>
               <Typo variant='h2'>Send notifikasjon når:</Typo>
               <FormGroup>

--- a/src/pages/innstillinger.tsx
+++ b/src/pages/innstillinger.tsx
@@ -31,12 +31,8 @@ const useStyles = makeStyles({
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
   try {
-    const mySettings = await prisma.employeeSettings.upsert({
+    const mySettings = await prisma.employeeSettings.findUnique({
       where: {
-        employeeId: session?.user?.id,
-      },
-      update: {},
-      create: {
         employeeId: session?.user?.id,
       },
     });

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -40,7 +40,7 @@ enum NotificationType {
 model EmployeeSettings {
   employeeId           Int                @id
   employee             Employee           @relation("settings", fields: [employeeId], references: [id])
-  slack                String?            @unique
+  slack                Boolean            @default(true)
   notificationSettings NotificationType[]
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -252,16 +252,24 @@ export const filterAndSearchEmployees = (searchText: string, employeeFilters: Em
   return result;
 };
 
-export const slackMessager = async (channel, text) => {
+export const slackMessager = async (email, text) => {
   try {
-    await axios.post(
-      'https://slack.com/api/chat.postMessage',
-      qs.stringify({
-        token: process.env.SLACK_TOKEN,
-        channel: channel,
-        text: text,
-      }),
-    );
+    const response = await axios.get(`https://slack.com/api/users.lookupByEmail?email=${email}`, {
+      headers: {
+        Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+      },
+    });
+    const userInSlackWorkspace = response.data.user;
+    if (userInSlackWorkspace) {
+      await axios.post(
+        'https://slack.com/api/chat.postMessage',
+        qs.stringify({
+          token: process.env.SLACK_TOKEN,
+          channel: response.data.user.id,
+          text: text,
+        }),
+      );
+    }
   } catch (err) {
     // eslint-disable-next-line
     console.log(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,16 +775,16 @@
     chalk "^4.0.0"
 
 "@material-ui/core@^5.0.0-alpha.24":
-  version "5.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-5.0.0-alpha.29.tgz#a3d6b7acf07f29e21819cdf452173aadcad25a90"
-  integrity sha512-Fxyz4w+OFy097oUz7Gz2d+9S8UAwxyQowC0wkaUDJ4J+aXx+bLD68E2YlFNHVYJM9FsOZhvjNkN2zfd1+7uevQ==
+  version "5.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-5.0.0-alpha.30.tgz#b9a251ab357f2848b49bdf9b0f725b97f0ed210f"
+  integrity sha512-g3NSMDz00rtyLHFGKA8x3QXWFVeBzuL6Mm+hrE7AAEXc+WhHMUw4T7yz9YQ0QYrcu9+yAWXktm3Gl8vuD2fp1Q==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/styled-engine" "5.0.0-alpha.25"
-    "@material-ui/styles" "5.0.0-alpha.29"
+    "@material-ui/styles" "5.0.0-alpha.30"
     "@material-ui/system" "5.0.0-alpha.29"
     "@material-ui/types" "5.1.7"
-    "@material-ui/unstyled" "5.0.0-alpha.29"
+    "@material-ui/unstyled" "5.0.0-alpha.30"
     "@material-ui/utils" "5.0.0-alpha.29"
     "@popperjs/core" "^2.4.4"
     "@types/react-transition-group" "^4.2.0"
@@ -811,10 +811,10 @@
     "@emotion/cache" "^11.0.0"
     prop-types "^15.7.2"
 
-"@material-ui/styles@5.0.0-alpha.29", "@material-ui/styles@^5.0.0-alpha.24":
-  version "5.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-5.0.0-alpha.29.tgz#3556f03663dc7caeb3ee6b720dac863ffb50fcf4"
-  integrity sha512-DOkN9SYwsfMp/B1KFeHkq9WhNNURw7k/hCoQuRPhnsm1rHY7rUMcEDXetePZEztvxA6WX67QJQRPcwovJ6ji/Q==
+"@material-ui/styles@5.0.0-alpha.30", "@material-ui/styles@^5.0.0-alpha.24":
+  version "5.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-5.0.0-alpha.30.tgz#0bcb9a57c839f1005f7b3f3985ddd42f140b9492"
+  integrity sha512-2E8ur6fUtLszgD5hStc7UDAdCTVN6BApq7Nhemzn86LEudIsC+KUMs0nm5pUj4EGRI+3TAFKw6Ma9BIWzpc64w==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"
@@ -848,10 +848,10 @@
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.7.tgz#b1fe7b94a1e091ba8a5ac12aaace570b23aa7cfa"
   integrity sha512-OSpB0gEKZm5h4izTLyipb34PkfazpvusgQMDTmFkSuqcKoChTshfGejEYX6uaZ+4m5xlT5qzihE6eKA+JnjELg==
 
-"@material-ui/unstyled@5.0.0-alpha.29":
-  version "5.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@material-ui/unstyled/-/unstyled-5.0.0-alpha.29.tgz#5266b2e926dd5b26071214f226b19ecedf3a5d7e"
-  integrity sha512-nhtoQ9FT6H4W9udKXlv5R+7y+xmBcKgUoJip588Pq9mLzNwga5n9LHBSU9a6ADcgXCd8wNHGIqqg+oB1qC/BCw==
+"@material-ui/unstyled@5.0.0-alpha.30":
+  version "5.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/@material-ui/unstyled/-/unstyled-5.0.0-alpha.30.tgz#e543e3a92f347e54638a866c1df56d86137ace1e"
+  integrity sha512-eslKNd7WWXA9JN9BLLRUJGU5KZ6dPvbLuUE18lfW/8A9Znvz+FVD9Fuio74izRxq3vEHkZDkS/CyaB4sSB/KeQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "5.0.0-alpha.29"
@@ -1857,15 +1857,15 @@ browserslist@4.16.1:
     node-releases "^1.1.69"
 
 browserslist@^4.14.5:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
-  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.4.tgz#7ebf913487f40caf4637b892b268069951c35d58"
+  integrity sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==
   dependencies:
-    caniuse-lite "^1.0.30001181"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.649"
+    caniuse-lite "^1.0.30001208"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.712"
     escalade "^3.1.1"
-    node-releases "^1.1.70"
+    node-releases "^1.1.71"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -1982,7 +1982,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001181:
+caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001208:
   version "1.0.30001208"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
   integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
@@ -2264,7 +2264,7 @@ color@^3.1.3:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
-colorette@^1.2.1:
+colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -2845,7 +2845,7 @@ ejs@^3.1.3:
   dependencies:
     jake "^10.6.1"
 
-electron-to-chromium@^1.3.634, electron-to-chromium@^1.3.649:
+electron-to-chromium@^1.3.634, electron-to-chromium@^1.3.712:
   version "1.3.712"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz#ae467ffe5f95961c6d41ceefe858fc36eb53b38f"
   integrity sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==
@@ -5717,7 +5717,7 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^1.1.69, node-releases@^1.1.70:
+node-releases@^1.1.69, node-releases@^1.1.71:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==


### PR DESCRIPTION
Man behøver ikke lenger finne ID til Slack-brukeren sin for å registrere at man ønsker å få disse varslingene. Benytter Slack-apiet til å finne ID ved hjelp av mailen til den innloggede brukeren. 
I tillegg har jeg testet alle mulige scenarioer for varslinger, og alt burde fungere som det skal. 

EmployeeSettings blir opprettet når brukeren går inn på innstillinger-siden, men fungerer også helt fint dersom denne raden ikke eksisterer. Da vil systemet fortsette som om brukeren ikke ønsker noen varslinger. 

![image](https://user-images.githubusercontent.com/49594236/114366253-8e8fbf00-9b7b-11eb-9a2f-5740cb5ad6b3.png)

![image](https://user-images.githubusercontent.com/49594236/114366300-9e0f0800-9b7b-11eb-8c23-fe96c25ac5b6.png)

