### PR TITLE
Refactor/remove cron date

### DIFF
--- a/src/components/form/EmployeeSelector.tsx
+++ b/src/components/form/EmployeeSelector.tsx
@@ -45,6 +45,7 @@ const EmployeeSelectorComponent = ({
     employees: undefined,
     employeeTask: undefined,
     employeeSettings: undefined,
+    activeYear: new Date(),
   },
 }: EmployeeSelectorComponentProps) => {
   return (

--- a/src/components/views/mine-ansatte/UserRow.tsx
+++ b/src/components/views/mine-ansatte/UserRow.tsx
@@ -33,6 +33,7 @@ export type EmployeeRow = {
   tasksFinished: number;
   totalTasks: number;
   employeeTask: IEmployeeTask[];
+  activeYear: Date;
 };
 
 type UserRowProps = {
@@ -47,7 +48,7 @@ const UserRow = ({ employee, slug }: UserRowProps) => {
 
   return (
     <TableRow className={classes.pointer} hover>
-      <TableCell onClick={() => router.push(`/ansatt/${employee.id}?år=${new Date(employee.employeeTask[0].dueDate).getFullYear()}&prosess=${slug}`)}>
+      <TableCell onClick={() => router.push(`/ansatt/${employee.id}?år=${new Date(employee.activeYear).getFullYear()}&prosess=${slug}`)}>
         <div className={classes.userRow} tabIndex={0}>
           <Avatar className={classes.avatar} firstName={employee.firstName} image={employee.image || ''} lastName={employee.lastName} />
           <Typo noWrap variant={typoVariant}>

--- a/src/components/views/mine-oppgaver/TaskRow.tsx
+++ b/src/components/views/mine-oppgaver/TaskRow.tsx
@@ -69,7 +69,13 @@ const TaskRow = ({ data }: { data: IEmployeeTask }) => {
       </div>
       <div
         className={classnames(classes.avatarRoot, classes.onClick)}
-        onClick={() => router.push(`/ansatt/${data.employee.id}?år=${new Date(data.dueDate).getFullYear()}&prosess=${data.task.phase.processTemplate.slug}`)}>
+        onClick={() =>
+          router.push(
+            `/ansatt/${data.employee.id}?${
+              data.task.phase.processTemplate.slug === 'lopende' ? `år=${new Date(data.employee.activeYear).getFullYear()}&` : ''
+            }prosess=${data.task.phase.processTemplate.slug}`,
+          )
+        }>
         <Avatar className={classes.avatar} firstName={data.employee.firstName} image={data.employee.imageUrl} lastName={data.employee.lastName} />
         <Typo noWrap>{`${data.employee.firstName} ${data.employee.lastName}`}</Typo>
       </div>

--- a/src/components/views/prosessmal/PhaseModal.tsx
+++ b/src/components/views/prosessmal/PhaseModal.tsx
@@ -26,7 +26,6 @@ type PhaseData = {
   offset: Offset;
   dueDateDayOffset: number;
   dueDate: string;
-  cronDate?: string;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -56,7 +55,6 @@ const PhaseModal = ({ processTemplate, modalIsOpen, closeModal, phase_id = undef
         dueDateDayOffset: phase?.dueDateDayOffset,
         offset: phase?.offset,
         dueDate: phase?.dueDate,
-        cronDate: phase?.cronDate,
       }),
       [phase],
     ),
@@ -70,7 +68,6 @@ const PhaseModal = ({ processTemplate, modalIsOpen, closeModal, phase_id = undef
           dueDate: moment(res.data.dueDate).format('yyyy-MM-DD'),
           offset: res.data.dueDateDayOffset <= 0 ? Offset.Before : Offset.After,
           dueDateDayOffset: Math.abs(res.data.dueDateDayOffset),
-          cronDate: moment(res.data.cronDate).format('yyyy-MM-DD'),
         });
       });
     }
@@ -82,7 +79,6 @@ const PhaseModal = ({ processTemplate, modalIsOpen, closeModal, phase_id = undef
       dueDateDayOffset: phase?.dueDateDayOffset,
       offset: phase?.offset,
       dueDate: phase?.dueDate,
-      cronDate: phase?.cronDate,
     });
   }, [phase]);
 
@@ -96,7 +92,6 @@ const PhaseModal = ({ processTemplate, modalIsOpen, closeModal, phase_id = undef
         ...formData,
         dueDate: new Date(formData.dueDate),
         dueDateDayOffset: formData.offset === Offset.Before ? -Math.abs(formData.dueDateDayOffset) : Math.abs(formData.dueDateDayOffset),
-        cronDate: new Date(formData.cronDate),
       },
       processTemplateId: processTemplate.id,
     };
@@ -202,22 +197,6 @@ const PhaseModal = ({ processTemplate, modalIsOpen, closeModal, phase_id = undef
                 </>
               }
               name={'dueDate'}
-              register={register}
-              type='date'
-            />
-            <TextField
-              defaultValue={moment().format('yyyy-MM-DD')}
-              errors={errors}
-              inputProps={{ min: `${new Date().getFullYear()}-01-01`, max: `${new Date().getFullYear()}-12-31` }}
-              label={
-                <>
-                  Automatisk opprettelse
-                  <Tooltip title='Dato for automatisk opprettelse av oppgaver i fasen. På denne datoen vil alle oppgavene i fasen bli opprettet for alle ansatte'>
-                    <HelpIcon />
-                  </Tooltip>
-                </>
-              }
-              name={'cronDate'}
               register={register}
               type='date'
             />

--- a/src/components/views/prosessmal/TaskRow.tsx
+++ b/src/components/views/prosessmal/TaskRow.tsx
@@ -1,5 +1,6 @@
-import { Avatar, IconButton, makeStyles, TableCell, TableRow } from '@material-ui/core';
+import { IconButton, makeStyles, TableCell, TableRow } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
+import Avatar from 'components/Avatar';
 import TaskModal from 'components/views/prosessmal/TaskModal';
 import { useState } from 'react';
 import { IPhase, ITask } from 'utils/types';
@@ -46,9 +47,12 @@ const TaskRow = ({ task, phase }: TaskProps) => {
       <TableCell style={{ width: '20rem' }}>
         {task.responsible && (
           <div className={classes.flexCenter}>
-            <Avatar className={classes.avatarSize} src={task.responsible.imageUrl}>
-              X
-            </Avatar>
+            <Avatar
+              className={classes.avatarSize}
+              firstName={task.responsible.firstName}
+              image={task.responsible.imageUrl}
+              lastName={task.responsible.lastName}
+            />
             {`${task.responsible.firstName} ${task.responsible.lastName}`}
           </div>
         )}

--- a/src/fixtures/phase.yml
+++ b/src/fixtures/phase.yml
@@ -20,22 +20,18 @@ items:
   phase5:
     title: 'Kvartal 1'
     processTemplate: '@processTemplate2'
-    cronDate: <%= new Date("2021-12-15").toISOString() %>
     dueDate: <%= new Date("2021-03-31").toISOString() %>
   phase6:
     title: 'Kvartal 2'
     processTemplate: '@processTemplate2'
-    cronDate: <%= new Date("2021-03-15").toISOString() %>
     dueDate: <%= new Date("2021-06-30").toISOString() %>
   phase7:
     title: 'Kvartal 3'
     processTemplate: '@processTemplate2'
-    cronDate: <%= new Date("2021-06-15").toISOString() %>
     dueDate: <%= new Date("2021-09-30").toISOString() %>
   phase8:
     title: 'Kvartal 4'
     processTemplate: '@processTemplate2'
-    cronDate: <%= new Date("2021-09-15").toISOString() %>
     dueDate: <%= new Date("2021-12-31").toISOString() %>
   phase9:
     title: 'Praktisk før fratredelse'

--- a/src/pages/alle-ansatte/[slug].tsx
+++ b/src/pages/alle-ansatte/[slug].tsx
@@ -67,6 +67,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
       id: true,
       firstName: true,
       lastName: true,
+      activeYear: true,
       profession: {
         select: {
           title: true,

--- a/src/pages/alle-oppgaver.tsx
+++ b/src/pages/alle-oppgaver.tsx
@@ -64,6 +64,7 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
           firstName: true,
           lastName: true,
           imageUrl: true,
+          activeYear: true,
         },
       },
       task: {

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -38,13 +38,14 @@ const useStyles = makeStyles({
   },
 });
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
-  const { id, år: year, prosess: process } = query;
+  const { id, år: year = null, prosess: process } = query;
   const parsedId = typeof id === 'string' && parseInt(id);
-  if (!id || !process || !year) {
+  if ((process === 'lopende' && !year) || !id || !process) {
     return {
       notFound: true,
     };
   }
+
   const employeeQuery = await prisma.employee.findUnique({
     where: {
       id: parsedId,
@@ -64,10 +65,12 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
       },
       employeeTask: {
         where: {
-          dueDate: {
-            gte: moment(year.toString()).startOf('year').toDate(),
-            lte: moment(year.toString()).endOf('year').toDate(),
-          },
+          ...(process === 'lopende' && {
+            dueDate: {
+              gte: moment(year.toString()).startOf('year').toDate(),
+              lte: moment(year.toString()).endOf('year').toDate(),
+            },
+          }),
           task: {
             phase: {
               processTemplate: {
@@ -185,7 +188,7 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const history = allTasks.map((process) => {
     const years = flattenDeep(process.years);
     const uniqeYears = uniq(years);
-    return { title: process.title, slug: process.slug, years: uniqeYears };
+    return { title: process.title, slug: process.slug, years: process.slug === 'lopende' ? uniqeYears : Array(uniqeYears.length ? 1 : 0) };
   });
 
   return { props: { employee, phasesWithTasks, year, process, history } };
@@ -247,10 +250,11 @@ const Employee = ({ employee, phasesWithTasks, year, process, history }: InferGe
               open={Boolean(anchorEl)}>
               {history.map((process) => {
                 return process.years.map((year) => {
-                  const linkText = `${year} ${process.title}`;
+                  const linkText = `${process.slug === 'lopende' ? year : ''} ${process.title}`;
+                  const link = `/ansatt/${employee.id}?${process.slug === 'lopende' ? `år=${year}&` : ''}prosess=${process.slug}`;
                   return (
                     <MenuItem key={`${process.title} ${year}`} onClick={handleClose}>
-                      <Link href={`/ansatt/${employee.id}?år=${year}&prosess=${process.slug}`}>
+                      <Link href={link}>
                         <a style={{ textDecoration: 'none', color: theme.palette.text.primary }}>{linkText}</a>
                       </Link>
                     </MenuItem>

--- a/src/pages/api/cron/phases.ts
+++ b/src/pages/api/cron/phases.ts
@@ -19,7 +19,6 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
       select: {
         id: true,
         title: true,
-        cronDate: true,
         dueDate: true,
         dueDateDayOffset: true,
         processTemplate: {

--- a/src/pages/api/phases.ts
+++ b/src/pages/api/phases.ts
@@ -15,7 +15,6 @@ export default withAuth(async function (req: NextApiRequest, res: NextApiRespons
         processTemplateId: processTemplateId,
         dueDateDayOffset: data.dueDateDayOffset,
         dueDate: data.dueDate,
-        cronDate: data.cronDate,
       },
     });
     res.status(HttpStatusCode.CREATED).json(newPhase);

--- a/src/pages/api/phases/[phase_id].ts
+++ b/src/pages/api/phases/[phase_id].ts
@@ -36,7 +36,6 @@ const GET = async (res, phase_id) => {
         title: true,
         dueDateDayOffset: true,
         dueDate: true,
-        cronDate: true,
       },
     });
     if (!phase) {
@@ -65,7 +64,6 @@ const PUT = async (req, res, phase_id) => {
         title: data.title,
         dueDateDayOffset: data.dueDateDayOffset,
         dueDate: data.dueDate,
-        cronDate: data.cronDate,
       },
     });
     res.status(HttpStatusCode.OK).json(updatedPhase);

--- a/src/pages/mine-ansatte/[slug].tsx
+++ b/src/pages/mine-ansatte/[slug].tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       slug: true,
       phases: {
         orderBy: {
-          createdAt: 'asc',
+          dueDate: 'asc',
         },
         select: {
           id: true,
@@ -82,6 +82,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       id: true,
       firstName: true,
       lastName: true,
+      activeYear: true,
       profession: {
         select: {
           title: true,
@@ -112,6 +113,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
               phase: {
                 select: {
                   title: true,
+                  processTemplate: {
+                    select: {
+                      slug: true,
+                    },
+                  },
                 },
               },
             },
@@ -130,9 +136,21 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 export const addFinishedTasks = (filteredEmployees: IEmployee[], phase: IPhase) => {
   filteredEmployees.forEach((employee: IEmployee) => {
     employee['tasksFinished'] = employee.employeeTask.filter(
-      (employeeTask: IEmployeeTask) => employeeTask.completed && employeeTask.task.phase.title === phase.title,
+      (employeeTask: IEmployeeTask) =>
+        employeeTask.completed &&
+        employeeTask.task.phase.title === phase.title &&
+        (employeeTask.task.phase.processTemplate.slug === 'lopende'
+          ? new Date(employeeTask.dueDate).getFullYear() === new Date(employee.activeYear).getFullYear()
+          : true),
     ).length;
-    employee['totalTasks'] = employee.employeeTask.filter((employeeTask: IEmployeeTask) => employeeTask.task.phase.title === phase.title).length;
+
+    employee['totalTasks'] = employee.employeeTask.filter(
+      (employeeTask: IEmployeeTask) =>
+        employeeTask.task.phase.title === phase.title &&
+        (employeeTask.task.phase.processTemplate.slug === 'lopende'
+          ? new Date(employeeTask.dueDate).getFullYear() === new Date(employee.activeYear).getFullYear()
+          : true),
+    ).length;
   });
 };
 

--- a/src/pages/mine-oppgaver.tsx
+++ b/src/pages/mine-oppgaver.tsx
@@ -68,6 +68,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
           firstName: true,
           lastName: true,
           imageUrl: true,
+          activeYear: true,
         },
       },
       task: {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -71,7 +71,6 @@ model Phase {
   processTemplateId String
   createdAt         DateTime        @default(now())
   dueDateDayOffset  Int?
-  cronDate          DateTime?
   dueDate           DateTime?
   processTemplate   ProcessTemplate @relation(fields: [processTemplateId], references: [id])
   tasks             Task[]

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Employee {
   terminationDate         DateTime?
   imageUrl                String?
   hrManagerId             Int?
+  activeYear              DateTime          @default(now()) @db.Date
   hrManager               Employee?         @relation("EmployeeToEmployee", fields: [hrManagerId], references: [id])
   profession              Profession        @relation(fields: [professionId], references: [id])
   employees               Employee[]        @relation("EmployeeToEmployee")

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -11,6 +11,7 @@ export type IEmployee = {
   profession: IProfession;
   hrManager: IEmployee;
   hrManagerId?: number;
+  activeYear: Date;
   employees: IEmployee[];
   employeeSettings: IEmployeeSettings;
   employeeTask: IEmployeeTask[];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -60,7 +60,6 @@ export type IPhase = {
   tasks?: ITask[];
   dueDate?: Date;
   dueDateDayOffset?: number;
-  cronDate?: Date;
 };
 
 export type IProcessTemplate = {


### PR DESCRIPTION
Denne PR ble litt større enn først antatt, but it is what it is. Følgende endringer er gjort:
- Erstattet avatar i Prosessmal
- Fjernet feltet for automatisk opprettelse av løpende prosesser både i database og frontend
- Gjort offboarding og onboarding-prosessen årsuavhengig. Det vil si at om en fase har dueDate i 2020, mens de resterende har i 2021 vil det ikke være noe problem. Alt vil bli samlet på en side. 
- Enhver ansatt har nå en "activeYear"-felt i entiteten. Dette for å unngå å gjøre den samme beregningen for en ansatt hver gang man er inne på en ansatt side, men heller gjør den en gang i året. 
- Oppdatert alle linker til ansattsiden slik at de som linker til en løpende prosess benytter "activeYear"-attributen, mens de resterende kun linker til prosessen, og ikke året. 

![image](https://user-images.githubusercontent.com/49594236/114535802-b69d2200-9c50-11eb-89c0-b8bde9f6cf27.png)

![image](https://user-images.githubusercontent.com/49594236/114536124-109de780-9c51-11eb-8c31-5724b95c43ea.png)

