### PR TITLE
refactor(Reusable): Made some reusable components

### DIFF
--- a/src/components/CenteringRow.tsx
+++ b/src/components/CenteringRow.tsx
@@ -1,0 +1,15 @@
+import { Box, BoxProps } from '@material-ui/core';
+
+export type CenteringRowProps = {
+  children: JSX.Element | JSX.Element[];
+} & BoxProps;
+
+const CenteringRow = ({ children, ...args }: CenteringRowProps) => {
+  return (
+    <Box {...args} alignItems='center' display='flex' flexDirection='row'>
+      {children}
+    </Box>
+  );
+};
+
+export default CenteringRow;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles({
     marginLeft: '30px',
     marginRight: '30px',
     marginTop: '60px',
+    marginBottom: '30px',
     [theme.breakpoints.down('md')]: {
       marginLeft: '10px',
     },

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,0 +1,31 @@
+import { makeStyles } from '@material-ui/core';
+import classNames from 'classnames';
+import Typo from 'components/Typo';
+import theme from 'theme';
+export type PageTitleProps = {
+  title: string;
+  subtitle?: string;
+};
+
+const useStyles = makeStyles({
+  title: {
+    lineHeight: 0.7,
+  },
+  gutterBottom: {
+    marginBottom: theme.spacing(2),
+  },
+});
+
+const PageTitle = ({ title, subtitle }: PageTitleProps) => {
+  const classes = useStyles();
+  return (
+    <div>
+      <Typo className={classNames(classes.title, classes.gutterBottom)} variant='h1'>
+        {title}
+      </Typo>
+      <Typo variant='h2'>{subtitle}</Typo>
+    </div>
+  );
+};
+
+export default PageTitle;

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -4,13 +4,9 @@ import ClearIcon from '@material-ui/icons/Clear';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import theme from 'theme';
+
+import CenteringRow from './CenteringRow';
 const useStyles = makeStyles({
-  centeringRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-  },
   textField: {
     height: theme.spacing(4),
   },
@@ -51,7 +47,7 @@ const SearchFilter = ({ filterComponent, search, activeFilters }: SearchFilterPr
   const open = Boolean(anchorEl);
   const id = open ? 'filter' : undefined;
   return (
-    <div className={classes.centeringRow}>
+    <CenteringRow justifyContent='flex-end'>
       {displaySearch ? (
         <Fade in timeout={100}>
           <TextField
@@ -108,7 +104,7 @@ const SearchFilter = ({ filterComponent, search, activeFilters }: SearchFilterPr
         }}>
         {filterComponent}
       </Popover>
-    </div>
+    </CenteringRow>
   );
 };
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -167,7 +167,8 @@ const LoggedInUserCard = ({ user, displayNotifications, setDisplayNotifications 
         display='flex'
         onClick={() => setDisplayNotifications(!displayNotifications)}
         onKeyPress={() => setDisplayNotifications(!displayNotifications)}
-        tabIndex={-1}>
+        role='button'
+        tabIndex={0}>
         <Box flex={3} mb={theme.spacing(1)}>
           <Badge badgeContent={notifications.filter((notification) => !notification.read).length} color='error'>
             {user ? (
@@ -181,7 +182,6 @@ const LoggedInUserCard = ({ user, displayNotifications, setDisplayNotifications 
           {user ? <Typo variant='body2'>{name}</Typo> : <Skeleton variant='text' width={100} />}
         </Box>
       </Box>
-
       {displayNotifications && (
         <>
           <Box alignItems='center' className={classes.gutterBottom} display='flex' flexDirection='column'>
@@ -210,7 +210,7 @@ const LoggedInUserCard = ({ user, displayNotifications, setDisplayNotifications 
           )}
 
           <Box alignItems='flex-end' display='flex' flexDirection='column-reverse'>
-            <IconButton aria-label='Lukk boks' onClick={() => setDisplayNotifications(false)}>
+            <IconButton aria-expanded={displayNotifications} aria-label='Lukk profil' onClick={() => setDisplayNotifications(false)}>
               <ExpandLessIcon />
             </IconButton>
           </Box>

--- a/src/components/views/mine-ansatte/PhaseCard.tsx
+++ b/src/components/views/mine-ansatte/PhaseCard.tsx
@@ -26,12 +26,10 @@ const PhaseCard = ({ title, amount, employees, slug }: PhaseCardProps) => {
     <>
       <ButtonBase aria-expanded={hidden} aria-label={`Ansatte i ${title}`} focusRipple onClick={() => setIsHidden(!hidden)}>
         <CenteringRow className={classes.pointer}>
-          <>
-            <Typo variant='body1'>
-              {title} (<b>{amount}</b>)
-            </Typo>
-            {hidden ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-          </>
+          <Typo variant='body1'>
+            {title} (<b>{amount}</b>)
+          </Typo>
+          {hidden ? <ExpandMoreIcon /> : <ExpandLessIcon />}
         </CenteringRow>
       </ButtonBase>
       <Box display={hidden ? 'none' : 'block'}>

--- a/src/components/views/mine-ansatte/PhaseCard.tsx
+++ b/src/components/views/mine-ansatte/PhaseCard.tsx
@@ -1,17 +1,12 @@
 import { Box, ButtonBase, Hidden, makeStyles, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import { ExpandLess as ExpandLessIcon, ExpandMore as ExpandMoreIcon } from '@material-ui/icons';
-import classNames from 'classnames';
+import CenteringRow from 'components/CenteringRow';
 import Typo from 'components/Typo';
 import UserRow from 'components/views/mine-ansatte/UserRow';
 import { EmployeeRow } from 'components/views/mine-ansatte/UserRow';
 import React, { useState } from 'react';
 
 const useStyles = makeStyles({
-  centeringRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
   pointer: {
     cursor: 'pointer',
   },
@@ -30,12 +25,14 @@ const PhaseCard = ({ title, amount, employees, slug }: PhaseCardProps) => {
   return (
     <>
       <ButtonBase aria-expanded={hidden} aria-label={`Ansatte i ${title}`} focusRipple onClick={() => setIsHidden(!hidden)}>
-        <div className={classNames(classes.centeringRow, classes.pointer)}>
-          <Typo variant='h2'>
-            {title} (<b>{amount}</b>)
-          </Typo>
-          {hidden ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-        </div>
+        <CenteringRow className={classes.pointer}>
+          <>
+            <Typo variant='body1'>
+              {title} (<b>{amount}</b>)
+            </Typo>
+            {hidden ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+          </>
+        </CenteringRow>
       </ButtonBase>
       <Box display={hidden ? 'none' : 'block'}>
         {employees.length > 0 ? (

--- a/src/components/views/mine-oppgaver/TaskRow.tsx
+++ b/src/components/views/mine-oppgaver/TaskRow.tsx
@@ -1,6 +1,7 @@
 import { ButtonBase, Checkbox, Hidden, IconButton, makeStyles, Tooltip } from '@material-ui/core';
 import { Launch, Mail } from '@material-ui/icons';
 import Avatar from 'components/Avatar';
+import CenteringRow from 'components/CenteringRow';
 import InfoModal from 'components/InfoModal';
 import Typo from 'components/Typo';
 import useSnackbar from 'context/Snackbar';
@@ -20,11 +21,6 @@ const useStyles = makeStyles({
   },
   completedTask: {
     textDecoration: 'line-through',
-  },
-  centeringRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
   },
   avatarRoot: {
     display: 'flex',
@@ -61,7 +57,7 @@ const TaskRow = ({ data }: { data: IEmployeeTask }) => {
 
   return (
     <>
-      <div className={classes.centeringRow}>
+      <CenteringRow>
         <Checkbox
           checked={completed}
           color='primary'
@@ -83,7 +79,7 @@ const TaskRow = ({ data }: { data: IEmployeeTask }) => {
           </Tooltip>
         )}
         {modalIsOpen && <InfoModal closeModal={() => setModalIsOpen(false)} employee_task_id={data.id} modalIsOpen={modalIsOpen} />}
-      </div>
+      </CenteringRow>
       <ButtonBase
         className={classes.avatarRoot}
         focusRipple

--- a/src/components/views/mine-oppgaver/TimeSection.tsx
+++ b/src/components/views/mine-oppgaver/TimeSection.tsx
@@ -53,23 +53,21 @@ const TimeSection = ({ section, index }: TimeSectionProps) => {
   return (
     <div className={classes.grid}>
       <CenteringRow>
-        <>
-          <Typo>
-            <b style={section.error && { color: theme.palette.error.main }}>{section.title}</b>
-            <span className={classes.disabled}>
-              {section.title && section.date && ' - '}
-              {section.date}
-            </span>
-          </Typo>
-          <IconButton
-            aria-controls={`${section.title || section.date} oppgaver`}
-            aria-expanded={open}
-            aria-label={`${section.title || section.date} oppgaver`}
-            onClick={() => setOpen(!open)}
-            size='small'>
-            {open ? <ExpandLess /> : <ExpandMore />}
-          </IconButton>
-        </>
+        <Typo>
+          <b style={section.error && { color: theme.palette.error.main }}>{section.title}</b>
+          <span className={classes.disabled}>
+            {section.title && section.date && ' - '}
+            {section.date}
+          </span>
+        </Typo>
+        <IconButton
+          aria-controls={`${section.title || section.date} oppgaver`}
+          aria-expanded={open}
+          aria-label={`${section.title || section.date} oppgaver`}
+          onClick={() => setOpen(!open)}
+          size='small'>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
       </CenteringRow>
       <Typo color='disabled' variant='body2'>
         {first && 'Gjelder'}

--- a/src/components/views/mine-oppgaver/TimeSection.tsx
+++ b/src/components/views/mine-oppgaver/TimeSection.tsx
@@ -1,6 +1,7 @@
 import { Divider, Hidden, IconButton } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/styles';
+import CenteringRow from 'components/CenteringRow';
 import Typo from 'components/Typo';
 import TaskRow from 'components/views/mine-oppgaver/TaskRow';
 import { TimeSectionType } from 'pages/mine-oppgaver';
@@ -15,6 +16,7 @@ type TimeSectionProps = {
 const useStyles = makeStyles({
   grid: {
     display: 'grid',
+    gridGap: theme.spacing(0.5),
     gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr',
     alignItems: 'end',
     marginBottom: theme.spacing(1),
@@ -34,11 +36,6 @@ const useStyles = makeStyles({
       gridColumn: 'span 2',
     },
   },
-  centeringRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
   disabled: {
     color: theme.palette.text.disabled,
   },
@@ -55,23 +52,25 @@ const TimeSection = ({ section, index }: TimeSectionProps) => {
   }
   return (
     <div className={classes.grid}>
-      <div className={classes.centeringRow}>
-        <Typo>
-          <b style={section.error && { color: theme.palette.error.main }}>{section.title}</b>
-          <span className={classes.disabled}>
-            {section.title && section.date && ' - '}
-            {section.date}
-          </span>
-        </Typo>
-        <IconButton
-          aria-controls={`${section.title || section.date} oppgaver`}
-          aria-expanded={open}
-          aria-label={`${section.title || section.date} oppgaver`}
-          onClick={() => setOpen(!open)}
-          size='small'>
-          {open ? <ExpandLess /> : <ExpandMore />}
-        </IconButton>
-      </div>
+      <CenteringRow>
+        <>
+          <Typo>
+            <b style={section.error && { color: theme.palette.error.main }}>{section.title}</b>
+            <span className={classes.disabled}>
+              {section.title && section.date && ' - '}
+              {section.date}
+            </span>
+          </Typo>
+          <IconButton
+            aria-controls={`${section.title || section.date} oppgaver`}
+            aria-expanded={open}
+            aria-label={`${section.title || section.date} oppgaver`}
+            onClick={() => setOpen(!open)}
+            size='small'>
+            {open ? <ExpandLess /> : <ExpandMore />}
+          </IconButton>
+        </>
+      </CenteringRow>
       <Typo color='disabled' variant='body2'>
         {first && 'Gjelder'}
       </Typo>

--- a/src/components/views/prosessmal/Phase.tsx
+++ b/src/components/views/prosessmal/Phase.tsx
@@ -25,7 +25,7 @@ const Phase = ({ phase, processTemplate }: PhaseProps) => {
   return (
     <div>
       <div className={classes.flexCenter}>
-        <Typo variant='h2'>{phase.title}</Typo>
+        <Typo variant='body1'>{phase.title}</Typo>
         <IconButton aria-label={`Endre fase ${phase.title}`} onClick={() => setModalIsOpen(true)}>
           <Edit />
         </IconButton>

--- a/src/pages/alle-ansatte/[slug].tsx
+++ b/src/pages/alle-ansatte/[slug].tsx
@@ -1,6 +1,6 @@
 import { Box } from '@material-ui/core';
+import PageTitle from 'components/PageTitle';
 import SearchFilter from 'components/SearchFilter';
-import Typo from 'components/Typo';
 import Filter from 'components/views/mine-ansatte/Filter';
 import PhaseCard from 'components/views/mine-ansatte/PhaseCard';
 import prisma from 'lib/prisma';
@@ -203,10 +203,7 @@ const MyEmployees = ({ myEmployees, allPhases }: InferGetServerSidePropsType<typ
       <Head>
         <title>Alle ansatte - {processTemplate.title}</title>
       </Head>
-      <Box>
-        <Typo variant='h1'>Alle ansatte</Typo>
-        <Typo variant='h2'>{processTemplate.title}</Typo>
-      </Box>
+      <PageTitle subtitle={processTemplate.title} title='Alle ansatte' />
       <SearchFilter
         activeFilters={Boolean(choosenProfession.length)}
         filterComponent={<Filter choosenProfession={choosenProfession} setChoosenProfession={setChoosenProfession} />}

--- a/src/pages/alle-oppgaver.tsx
+++ b/src/pages/alle-oppgaver.tsx
@@ -1,6 +1,6 @@
 import 'moment/locale/nb';
 
-import { makeStyles } from '@material-ui/core';
+import PageTitle from 'components/PageTitle';
 import SearchFilter from 'components/SearchFilter';
 import Typo from 'components/Typo';
 import Filter from 'components/views/mine-oppgaver/Filter';
@@ -12,25 +12,8 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
 import safeJsonStringify from 'safe-json-stringify';
-import theme from 'theme';
 import { IEmployeeTask, ITag } from 'utils/types';
 import { filterAndSearchTasks, splitIntoTimeSections } from 'utils/utils';
-
-const useStyles = makeStyles({
-  header: {
-    marginBottom: '2rem',
-  },
-  title: {
-    lineHeight: 0.7,
-  },
-  template_title: {
-    marginLeft: '3px',
-  },
-  gutterBottom: {
-    marginBottom: theme.spacing(2),
-  },
-});
-
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const { fullfort: completed } = query;
   const isCompleted = completed.toString() === 'true';
@@ -101,7 +84,6 @@ export type TimeSectionType = {
 };
 
 const MyTasks = ({ myTasks }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const classes = useStyles();
   const router = useRouter();
 
   const { fullfort: completed } = router.query;
@@ -123,12 +105,8 @@ const MyTasks = ({ myTasks }: InferGetServerSidePropsType<typeof getServerSidePr
         <title>Alle oppgaver</title>
       </Head>
       <>
-        <div className={classes.header}>
-          <Typo className={classes.title} variant='h1'>
-            Alle oppgaver
-          </Typo>
-          <Typo className={classes.template_title}>{completed.toString() === 'true' ? 'Fullførte' : 'Aktive'} oppgaver</Typo>
-        </div>
+        <PageTitle subtitle={`${completed.toString() === 'true' ? 'Fullførte' : 'Aktive'} oppgaver`} title='Alle oppgaver' />
+
         <SearchFilter
           activeFilters={Boolean(choosenTags.length || choosenProcessTemplates.length)}
           filterComponent={

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Menu, MenuItem } from '@material-ui/core';
+import HistoryIcon from '@material-ui/icons/History';
 import { makeStyles } from '@material-ui/styles';
 import Typo from 'components/Typo';
 import Phase from 'components/views/ansatt/Phase';
@@ -234,7 +235,8 @@ const Employee = ({ employee, phasesWithTasks, year, process, history }: InferGe
               aria-label='Historikk meny'
               color='primary'
               disabled={history.every((element) => !element.years.length)}
-              onClick={handleClick}>
+              onClick={handleClick}
+              startIcon={<HistoryIcon />}>
               Historikk
             </Button>
             <Menu

--- a/src/pages/mine-ansatte/[slug].tsx
+++ b/src/pages/mine-ansatte/[slug].tsx
@@ -1,6 +1,6 @@
 import { Box } from '@material-ui/core';
+import PageTitle from 'components/PageTitle';
 import SearchFilter from 'components/SearchFilter';
-import Typo from 'components/Typo';
 import Filter from 'components/views/mine-ansatte/Filter';
 import PhaseCard from 'components/views/mine-ansatte/PhaseCard';
 import prisma from 'lib/prisma';
@@ -214,10 +214,7 @@ const MyEmployees = ({ myEmployees, allPhases }: InferGetServerSidePropsType<typ
       <Head>
         <title>Mine ansatte - {processTemplate.title}</title>
       </Head>
-      <Box>
-        <Typo variant='h1'>Mine ansatte</Typo>
-        <Typo variant='h2'>{processTemplate.title}</Typo>
-      </Box>
+      <PageTitle subtitle={processTemplate.title} title='Mine ansatte' />
       <SearchFilter
         activeFilters={Boolean(choosenProfession.length)}
         filterComponent={<Filter choosenProfession={choosenProfession} setChoosenProfession={setChoosenProfession} />}

--- a/src/pages/mine-oppgaver.tsx
+++ b/src/pages/mine-oppgaver.tsx
@@ -1,6 +1,6 @@
 import 'moment/locale/nb';
 
-import { makeStyles } from '@material-ui/core';
+import PageTitle from 'components/PageTitle';
 import SearchFilter from 'components/SearchFilter';
 import Typo from 'components/Typo';
 import Filter from 'components/views/mine-oppgaver/Filter';
@@ -13,24 +13,9 @@ import { useRouter } from 'next/router';
 import { getSession } from 'next-auth/client';
 import { useMemo, useState } from 'react';
 import safeJsonStringify from 'safe-json-stringify';
-import theme from 'theme';
 import { IEmployeeTask, ITag } from 'utils/types';
 import { filterAndSearchTasks, splitIntoTimeSections } from 'utils/utils';
 
-const useStyles = makeStyles({
-  header: {
-    marginBottom: '2rem',
-  },
-  title: {
-    lineHeight: 0.7,
-  },
-  template_title: {
-    marginLeft: '3px',
-  },
-  gutterBottom: {
-    marginBottom: theme.spacing(2),
-  },
-});
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
   const { fullfort: completed } = context.query;
@@ -104,7 +89,6 @@ export type TimeSectionType = {
 };
 
 const MyTasks = ({ myTasks }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const classes = useStyles();
   const router = useRouter();
   const { fullfort: completed } = router.query;
 
@@ -124,12 +108,7 @@ const MyTasks = ({ myTasks }: InferGetServerSidePropsType<typeof getServerSidePr
         <title>Mine oppgaver</title>
       </Head>
       <>
-        <div className={classes.header}>
-          <Typo className={classes.title} variant='h1'>
-            Mine oppgaver
-          </Typo>
-          <Typo className={classes.template_title}>{completed.toString() === 'true' ? 'Fullførte' : 'Aktive'} oppgaver</Typo>
-        </div>
+        <PageTitle subtitle={`${completed.toString() === 'true' ? 'Fullførte' : 'Aktive'} oppgaver`} title='Mine oppgaver' />
         <SearchFilter
           activeFilters={Boolean(choosenTags.length || choosenProcessTemplates.length)}
           filterComponent={

--- a/src/pages/prosessmal/[slug].tsx
+++ b/src/pages/prosessmal/[slug].tsx
@@ -1,6 +1,5 @@
-import { makeStyles } from '@material-ui/core';
 import AddButton from 'components/AddButton';
-import Typo from 'components/Typo';
+import PageTitle from 'components/PageTitle';
 import Phase from 'components/views/prosessmal/Phase';
 import PhaseModal from 'components/views/prosessmal/PhaseModal';
 import { DataProvider } from 'context/Data';
@@ -10,18 +9,6 @@ import Head from 'next/head';
 import { useState } from 'react';
 import theme from 'theme';
 import { IPhase } from 'utils/types';
-
-const useStyles = makeStyles({
-  header: {
-    marginBottom: '2rem',
-  },
-  title: {
-    lineHeight: 0.7,
-  },
-  template_title: {
-    marginLeft: '7px',
-  },
-});
 
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const processTemplate = await prisma.processTemplate.findUnique({
@@ -77,7 +64,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
 };
 
 const ProcessTemplate = ({ processTemplate }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const classes = useStyles();
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
 
   return (
@@ -85,12 +71,7 @@ const ProcessTemplate = ({ processTemplate }: InferGetServerSidePropsType<typeof
       <Head>
         <title>Prosessmal {processTemplate && `- ${processTemplate.title}`}</title>
       </Head>
-      <div className={classes.header}>
-        <Typo className={classes.title} variant='h1'>
-          Prosessmal
-        </Typo>
-        <Typo className={classes.template_title}>{processTemplate?.title}</Typo>
-      </div>
+      <PageTitle subtitle={processTemplate?.title} title='Prosessmal' />
       <DataProvider>
         {processTemplate?.phases.map((phase: IPhase) => (
           <Phase key={phase.id} phase={phase} processTemplate={processTemplate} />


### PR DESCRIPTION
Følgende er blitt gjort:
- Lagt til mer luft mellom oppgavene i mine og alle oppgaver (se screenshot 1)
- Laget en felles komponent som brukes for tittelen på de ulike sidene (med unntak av Ansatt-siden)
- Laget en komponent som sentrerer alle children i en rad 
- Lagt til 30px med marginBottom på selve layouten
- Lagt til ikon til historikk for å følge det vi har gjort på tilsvarende knapper på siden (se scrrenshot 2)
- Gjort det mulig å navigere seg til "Innstillinger" og "Logg ut" med tabbing

![image](https://user-images.githubusercontent.com/49594236/115872243-dd720a00-a441-11eb-9ef0-8fd51684dd87.png)

![image](https://user-images.githubusercontent.com/49594236/115872816-891b5a00-a442-11eb-8132-e8a04ff4beb9.png)
